### PR TITLE
DAT-8016 Use AccessTokenProvider as Interface instead of Token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deliveryhero/google-auth-library",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "author": "Google Inc.",
   "description": "Google APIs Authentication Client Library for Node.js",
   "engines": {

--- a/src/auth/credentials.ts
+++ b/src/auth/credentials.ts
@@ -81,5 +81,4 @@ export interface JWTInput {
 export interface CredentialBody {
   client_email?: string;
   private_key?: string;
-  credentials?: Credentials;
 }

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -40,7 +40,7 @@ import {
   BaseExternalAccountClient,
 } from './baseexternalclient';
 import {AuthClient} from './authclient';
-import {SingleTokenClient} from './singletokenclient';
+import {IAccessTokenProvider, SingleTokenClient} from './singletokenclient';
 
 /**
  * Defines all types of explicit clients that are determined via ADC JSON
@@ -110,9 +110,9 @@ export interface GoogleAuthOptions {
   projectId?: string;
 
   /**
-   * Access Token.
+   * Access Token Provider
    */
-  token?: string;
+  accessTokenProvider?: IAccessTokenProvider;
 }
 
 export const CLOUD_SDK_CLIENT_ID =
@@ -145,6 +145,8 @@ export class GoogleAuth {
   // To save the access token
   accessToken: string | null = null;
 
+  accessTokenProvider: IAccessTokenProvider | null = null;
+
   cachedCredential: JSONClient | Impersonated | Compute | null = null;
 
   /**
@@ -168,7 +170,7 @@ export class GoogleAuth {
     this.scopes = opts.scopes;
     this.jsonContent = opts.credentials || null;
     this.clientOptions = opts.clientOptions;
-    this.accessToken = opts.token || null;
+    this.accessTokenProvider = opts.accessTokenProvider || null;
   }
 
   // GAPIC client libraries should always use self-signed JWTs. The following
@@ -753,12 +755,10 @@ export class GoogleAuth {
   private async getCredentialsAsync(): Promise<CredentialBody> {
     await this.getClient();
 
-    if (this.accessToken) {
+    if (this.accessTokenProvider) {
       const credential: CredentialBody = {};
       if (this.cachedCredential) {
-        credential.credentials = {
-          access_token: this.cachedCredential.credentials.access_token,
-        };
+        await (this.cachedCredential as SingleTokenClient).getAndUpdateCredentials();
       }
       return credential;
     }
@@ -802,8 +802,8 @@ export class GoogleAuth {
       );
     }
     if (!this.cachedCredential) {
-      if (this.accessToken) {
-        this.cachedCredential = new SingleTokenClient(this.accessToken);
+      if (this.accessTokenProvider) {
+          this.cachedCredential = new SingleTokenClient(this.accessTokenProvider);
       } else if (this.jsonContent) {
         this._cacheClientFromJSON(this.jsonContent, this.clientOptions);
       } else if (this.keyFilename) {

--- a/src/auth/googleauth.ts
+++ b/src/auth/googleauth.ts
@@ -804,6 +804,7 @@ export class GoogleAuth {
     if (!this.cachedCredential) {
       if (this.accessTokenProvider) {
           this.cachedCredential = new SingleTokenClient(this.accessTokenProvider);
+          await this.cachedCredential.getAndUpdateCredentials();
       } else if (this.jsonContent) {
         this._cacheClientFromJSON(this.jsonContent, this.clientOptions);
       } else if (this.keyFilename) {

--- a/src/auth/singletokenclient.ts
+++ b/src/auth/singletokenclient.ts
@@ -1,12 +1,35 @@
-import {OAuth2Client} from './oauth2client';
+import {GetTokenResponse, OAuth2Client} from './oauth2client';
+import {Credentials} from './credentials';
+
+export interface AccessToken {
+    accessToken: string;
+    expiryDate: number;
+}
+
+export interface IAccessTokenProvider {
+    fetchAccessToken: () => Promise<AccessToken>;
+}
 
 export class SingleTokenClient extends OAuth2Client {
-  constructor(accessToken: string) {
-    super();
-    this.setCredentials({access_token: accessToken});
-  }
 
-  fromJSON(): void {
-    throw new Error('Method not implemented');
-  }
+    constructor(private readonly accessTokenProvider: IAccessTokenProvider) {
+        super();
+    }
+
+    public async getAndUpdateCredentials(): Promise<Credentials> {
+        const accessToken: AccessToken = await this.accessTokenProvider.fetchAccessToken();
+        this.setCredentials({
+            access_token: accessToken.accessToken,
+            expiry_date: accessToken.expiryDate
+        });
+        return this.credentials;
+    }
+
+    protected async refreshToken(refreshToken?: string | null): Promise<GetTokenResponse> {
+        const credentials = await this.getAndUpdateCredentials();
+        return {
+            tokens: credentials,
+            res: null
+        }
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,9 +58,7 @@ export {
   BaseExternalAccountClientOptions,
 } from './auth/baseexternalclient';
 export {DefaultTransporter} from './transporters';
-export {
-  IAccessTokenProvider,
-} from './auth/singletokenclient';
+import './auth/singletokenclient';
 
 const auth = new GoogleAuth();
 export {auth, GoogleAuth};

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,9 @@ export {
   BaseExternalAccountClientOptions,
 } from './auth/baseexternalclient';
 export {DefaultTransporter} from './transporters';
+export {
+  IAccessTokenProvider,
+} from './auth/singletokenclient';
 
 const auth = new GoogleAuth();
 export {auth, GoogleAuth};

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export {
   BaseExternalAccountClientOptions,
 } from './auth/baseexternalclient';
 export {DefaultTransporter} from './transporters';
-import './auth/singletokenclient';
+export * from  './auth/singletokenclient';
 
 const auth = new GoogleAuth();
 export {auth, GoogleAuth};


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-nodejs/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

* Use AccessTokenProvider to make it easier for the intermediate library to get Vault token and integrate it with the google logic for refreshing token.
